### PR TITLE
Qp trying to fix scene reload breaking

### DIFF
--- a/space-trader/Assets/Prefabs/InventoryReadout.prefab
+++ b/space-trader/Assets/Prefabs/InventoryReadout.prefab
@@ -1,0 +1,338 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3484238984897559175
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 661915874630519595}
+  - component: {fileID: 1830889946400338009}
+  - component: {fileID: 4396965871137629391}
+  m_Layer: 5
+  m_Name: CurrentBalance
+  m_TagString: BalanceReadout
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &661915874630519595
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3484238984897559175}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6338081429660799101}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -125}
+  m_SizeDelta: {x: 0, y: -250}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1830889946400338009
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3484238984897559175}
+  m_CullTransparentMesh: 1
+--- !u!114 &4396965871137629391
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3484238984897559175}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: current balance goes here
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4280148474
+  m_fontColor: {r: 0.98039216, g: 0.88235295, b: 0.11372549, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 46.7
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 12
+  m_fontSizeMax: 60
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4190695477427330843
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6338081429660799101}
+  - component: {fileID: 684081524606457698}
+  - component: {fileID: 5814677422922424600}
+  m_Layer: 5
+  m_Name: InventoryReadout
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6338081429660799101
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4190695477427330843}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7241588863482349675}
+  - {fileID: 661915874630519595}
+  m_Father: {fileID: 0}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -662.5, y: -350}
+  m_SizeDelta: {x: -1375, y: -750}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &684081524606457698
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4190695477427330843}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7b8eab9ba31585e4194b75acb9b31fbf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  inventoryReadout: {fileID: 8411290203546797951}
+--- !u!114 &5814677422922424600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4190695477427330843}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44b1076dd0b298a4283f377f9a86659d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  balanceReadout: {fileID: 4396965871137629391}
+--- !u!1 &9059075975697088832
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7241588863482349675}
+  - component: {fileID: 6304637658240388546}
+  - component: {fileID: 8411290203546797951}
+  m_Layer: 5
+  m_Name: Inventory
+  m_TagString: InventoryReadout
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7241588863482349675
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9059075975697088832}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6338081429660799101}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 37.5}
+  m_SizeDelta: {x: 0, y: -75}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6304637658240388546
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9059075975697088832}
+  m_CullTransparentMesh: 1
+--- !u!114 &8411290203546797951
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9059075975697088832}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: inventory readout
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 46
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 10
+  m_fontSizeMax: 46
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}

--- a/space-trader/Assets/Prefabs/InventoryReadout.prefab.meta
+++ b/space-trader/Assets/Prefabs/InventoryReadout.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 96696d015473ba0419e1a185ca14225c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/space-trader/Assets/Prefabs/PauseScreenManager.prefab
+++ b/space-trader/Assets/Prefabs/PauseScreenManager.prefab
@@ -1,0 +1,62 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4397502396254974356
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5000625235756573691}
+  - component: {fileID: 3451666714641850573}
+  - component: {fileID: 1203710150723540262}
+  m_Layer: 0
+  m_Name: PauseScreenManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5000625235756573691
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4397502396254974356}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 996.8257, y: 523.57117, z: 0.3127222}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3451666714641850573
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4397502396254974356}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d315a136998b5d43b10ad0f9c027774, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pausemenu: {fileID: 0}
+--- !u!114 &1203710150723540262
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4397502396254974356}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bbb1eb8c72af3b34ba48d32a0c245542, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  title: {fileID: 0}
+  settings: {fileID: 0}

--- a/space-trader/Assets/Prefabs/PauseScreenManager.prefab.meta
+++ b/space-trader/Assets/Prefabs/PauseScreenManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cb0c6ac0de07d9a4e92d25bd259116ed
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/space-trader/Assets/Prefabs/PlayerInventoryManager.prefab
+++ b/space-trader/Assets/Prefabs/PlayerInventoryManager.prefab
@@ -1,0 +1,59 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3449974017456907810
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8698865630610943041}
+  - component: {fileID: 4666296983660380992}
+  m_Layer: 0
+  m_Name: PlayerInventoryManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8698865630610943041
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3449974017456907810}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4666296983660380992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3449974017456907810}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc3582324744d2443a25f25d2b6c41f3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 6624260759837310365, guid: 42275745f6474e641a982979568afcb4, type: 3}
+  allTradeItems:
+  - {fileID: 11400000, guid: c798a9ca1ecd1d949a2ca6605cfcb83f, type: 2}
+  - {fileID: 11400000, guid: 7f7ace02d81169345b650230d95a18b9, type: 2}
+  - {fileID: 11400000, guid: 109937338317fab48bd52b263e25527d, type: 2}
+  - {fileID: 11400000, guid: b9f42f612760af041bf810e0d340027e, type: 2}
+  - {fileID: 11400000, guid: c97bdbf23bf83a74497bf4472fdcca75, type: 2}
+  - {fileID: 11400000, guid: f814af457c26e304cb1edcd391a67607, type: 2}

--- a/space-trader/Assets/Prefabs/PlayerInventoryManager.prefab.meta
+++ b/space-trader/Assets/Prefabs/PlayerInventoryManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4b8236517f89f6c4b9fac263178ca6a1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/space-trader/Assets/Prefabs/RocketShip.prefab
+++ b/space-trader/Assets/Prefabs/RocketShip.prefab
@@ -1,0 +1,96 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &759216159499616267
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5487890491209082982}
+  - component: {fileID: 9042587954330933647}
+  - component: {fileID: 6624260759837310365}
+  - component: {fileID: 3225671280804838862}
+  m_Layer: 5
+  m_Name: RocketShip
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5487890491209082982
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 759216159499616267}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.11400001, y: 0.7734277}
+  m_AnchorMax: {x: 0.14400001, y: 0.8174339}
+  m_AnchoredPosition: {x: -1, y: 2}
+  m_SizeDelta: {x: 1.4783936, y: 2.4118042}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9042587954330933647
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 759216159499616267}
+  m_CullTransparentMesh: 1
+--- !u!114 &6624260759837310365
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 759216159499616267}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a958ced8e47955547ab586e8708579e4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ship: {fileID: 11400000, guid: ec03040c8fb4e224192412b310eac273, type: 2}
+  playerMoney: 0
+  cargoSpaceInUse: 0
+  inventoryReadout: {fileID: 0}
+  balanceReadout: {fileID: 0}
+--- !u!114 &3225671280804838862
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 759216159499616267}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/space-trader/Assets/Prefabs/RocketShip.prefab
+++ b/space-trader/Assets/Prefabs/RocketShip.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 3225671280804838862}
   m_Layer: 5
   m_Name: RocketShip
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -60,10 +60,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ship: {fileID: 11400000, guid: ec03040c8fb4e224192412b310eac273, type: 2}
-  playerMoney: 0
+  playerMoney: 1000
   cargoSpaceInUse: 0
-  inventoryReadout: {fileID: 0}
-  balanceReadout: {fileID: 0}
+  inventoryReadout: {fileID: 684081524606457698, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+  balanceReadout: {fileID: 5814677422922424600, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
 --- !u!114 &3225671280804838862
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/space-trader/Assets/Prefabs/RocketShip.prefab.meta
+++ b/space-trader/Assets/Prefabs/RocketShip.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 42275745f6474e641a982979568afcb4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/space-trader/Assets/Prefabs/TradeManager.prefab
+++ b/space-trader/Assets/Prefabs/TradeManager.prefab
@@ -45,4 +45,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   travelManager: {fileID: 0}
-  tradeWindow: {fileID: 0}
+  confirmationWindow: {fileID: 1427234159915820324, guid: 60cae071e0a5dd344a0b37bb4a7918a0, type: 3}
+  inventoryReadout: {fileID: 684081524606457698, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+  balanceReadout: {fileID: 5814677422922424600, guid: 96696d015473ba0419e1a185ca14225c, type: 3}

--- a/space-trader/Assets/Scenes/Game.unity
+++ b/space-trader/Assets/Scenes/Game.unity
@@ -2315,66 +2315,28 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1027455033}
   m_CullTransparentMesh: 1
---- !u!1 &1059356957
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1059356959}
-  - component: {fileID: 1059356958}
-  - component: {fileID: 1059356960}
-  m_Layer: 0
-  m_Name: PauseScreenManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1059356958
+--- !u!114 &1059356958 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 3451666714641850573, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+  m_PrefabInstance: {fileID: 2841092037785734028}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1059356957}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9d315a136998b5d43b10ad0f9c027774, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  pausemenu: {fileID: 2081158452}
---- !u!4 &1059356959
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1059356957}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 996.8257, y: 523.57117, z: 0.3127222}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1059356960
+--- !u!114 &1059356960 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 1203710150723540262, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+  m_PrefabInstance: {fileID: 2841092037785734028}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1059356957}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: bbb1eb8c72af3b34ba48d32a0c245542, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  title: {fileID: 0}
-  settings: {fileID: 0}
 --- !u!1 &1060547510
 GameObject:
   m_ObjectHideFlags: 0
@@ -2497,155 +2459,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1060547510}
   m_CullTransparentMesh: 1
---- !u!1 &1089233892
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1089233893}
-  - component: {fileID: 1089233895}
-  - component: {fileID: 1089233894}
-  - component: {fileID: 1089233896}
-  m_Layer: 5
-  m_Name: CurrentBalance
-  m_TagString: BalanceReadout
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1089233893
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1089233892}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1463780547}
-  m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -125}
-  m_SizeDelta: {x: 0, y: -250}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1089233894
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1089233892}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: current balance goes here
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4280148474
-  m_fontColor: {r: 0.98039216, g: 0.88235295, b: 0.11372549, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 46.7
-  m_fontSizeBase: 36
-  m_fontWeight: 400
-  m_enableAutoSizing: 1
-  m_fontSizeMin: 12
-  m_fontSizeMax: 60
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &1089233895
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1089233892}
-  m_CullTransparentMesh: 1
---- !u!114 &1089233896
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1089233892}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 44b1076dd0b298a4283f377f9a86659d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  balanceReadout: {fileID: 0}
 --- !u!1001 &1110645925
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3297,65 +3110,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1240248585}
   m_CullTransparentMesh: 1
---- !u!1 &1272761958
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1272761959}
-  - component: {fileID: 1272761960}
-  m_Layer: 0
-  m_Name: PlayerInventoryManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1272761959
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1272761958}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1272761960
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1272761958}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc3582324744d2443a25f25d2b6c41f3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  player: {fileID: 1333135970}
-  allTradeItems:
-  - {fileID: 11400000, guid: c798a9ca1ecd1d949a2ca6605cfcb83f, type: 2}
-  - {fileID: 11400000, guid: 7f7ace02d81169345b650230d95a18b9, type: 2}
-  - {fileID: 11400000, guid: 109937338317fab48bd52b263e25527d, type: 2}
-  - {fileID: 11400000, guid: b9f42f612760af041bf810e0d340027e, type: 2}
-  - {fileID: 11400000, guid: c97bdbf23bf83a74497bf4472fdcca75, type: 2}
-  - {fileID: 11400000, guid: f814af457c26e304cb1edcd391a67607, type: 2}
-  inventoryReadout: {fileID: 0}
-  balanceReadout: {fileID: 0}
 --- !u!114 &1317209634 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7909759382664706462, guid: c00c9572e7cc343f09bb3c4693cc4a3a, type: 3}
@@ -3372,58 +3126,20 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 8776183760068921493, guid: c00c9572e7cc343f09bb3c4693cc4a3a, type: 3}
   m_PrefabInstance: {fileID: 1415461471137710330}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1333135966
+--- !u!1 &1333135966 stripped
 GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 759216159499616267, guid: 42275745f6474e641a982979568afcb4, type: 3}
+  m_PrefabInstance: {fileID: 4064962110323734332}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1333135967}
-  - component: {fileID: 1333135969}
-  - component: {fileID: 1333135970}
-  - component: {fileID: 1333135971}
-  m_Layer: 5
-  m_Name: RocketShip
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1333135967
+--- !u!224 &1333135967 stripped
 RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+  m_PrefabInstance: {fileID: 4064962110323734332}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1333135966}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1166592174}
-  m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.11400001, y: 0.7734277}
-  m_AnchorMax: {x: 0.14400001, y: 0.8174339}
-  m_AnchoredPosition: {x: -1, y: 2}
-  m_SizeDelta: {x: 1.4783936, y: 2.4118042}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &1333135969
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1333135966}
-  m_CullTransparentMesh: 1
---- !u!114 &1333135970
+--- !u!114 &1333135970 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 6624260759837310365, guid: 42275745f6474e641a982979568afcb4, type: 3}
+  m_PrefabInstance: {fileID: 4064962110323734332}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1333135966}
   m_Enabled: 1
@@ -3431,39 +3147,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a958ced8e47955547ab586e8708579e4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ship: {fileID: 11400000, guid: ec03040c8fb4e224192412b310eac273, type: 2}
-  playerMoney: 0
-  cargoSpaceInUse: 0
---- !u!114 &1333135971
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1333135966}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1001 &1386867133
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3770,44 +3453,33 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1424099266}
   m_CullTransparentMesh: 1
---- !u!1 &1463780546
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1463780547}
-  m_Layer: 5
-  m_Name: InventoryReadout
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1463780547
+--- !u!224 &1463780547 stripped
 RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+  m_PrefabInstance: {fileID: 201352834290830268}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1463780546}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1963490254}
-  - {fileID: 1089233893}
-  m_Father: {fileID: 1865027708}
-  m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -662.5, y: -350}
-  m_SizeDelta: {x: -1375, y: -750}
-  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1463780548 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5814677422922424600, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+  m_PrefabInstance: {fileID: 201352834290830268}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44b1076dd0b298a4283f377f9a86659d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1463780549 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 684081524606457698, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+  m_PrefabInstance: {fileID: 201352834290830268}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7b8eab9ba31585e4194b75acb9b31fbf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1518560721
 GameObject:
   m_ObjectHideFlags: 0
@@ -4217,155 +3889,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   currentPlanet: {fileID: 1317209634}
   rocketShip: {fileID: 1333135966}
---- !u!1 &1963490253
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1963490254}
-  - component: {fileID: 1963490256}
-  - component: {fileID: 1963490255}
-  - component: {fileID: 1963490257}
-  m_Layer: 5
-  m_Name: Inventory
-  m_TagString: InventoryReadout
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1963490254
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1963490253}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1463780547}
-  m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 37.5}
-  m_SizeDelta: {x: 0, y: -75}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1963490255
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1963490253}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: inventory readout
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 46
-  m_fontSizeBase: 36
-  m_fontWeight: 400
-  m_enableAutoSizing: 1
-  m_fontSizeMin: 10
-  m_fontSizeMax: 46
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &1963490256
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1963490253}
-  m_CullTransparentMesh: 1
---- !u!114 &1963490257
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1963490253}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7b8eab9ba31585e4194b75acb9b31fbf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  inventoryReadout: {fileID: 0}
+  balanceReadout: {fileID: 1463780548}
 --- !u!1 &2081158452
 GameObject:
   m_ObjectHideFlags: 0
@@ -4446,6 +3970,107 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2081158452}
   m_CullTransparentMesh: 1
+--- !u!1001 &201352834290830268
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1865027708}
+    m_Modifications:
+    - target: {fileID: 4190695477427330843, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_Name
+      value: InventoryReadout
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -1375
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: -750
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -662.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -350
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6338081429660799101, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 96696d015473ba0419e1a185ca14225c, type: 3}
 --- !u!1001 &1415461471137710330
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4765,6 +4390,14 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1865027709}
     - target: {fileID: 9133593429255450730, guid: 178158e14e122db4aacaa61f767b0a07, type: 3}
+      propertyPath: balanceReadout
+      value: 
+      objectReference: {fileID: 1463780548}
+    - target: {fileID: 9133593429255450730, guid: 178158e14e122db4aacaa61f767b0a07, type: 3}
+      propertyPath: inventoryReadout
+      value: 
+      objectReference: {fileID: 1463780549}
+    - target: {fileID: 9133593429255450730, guid: 178158e14e122db4aacaa61f767b0a07, type: 3}
       propertyPath: confirmationWindow
       value: 
       objectReference: {fileID: 1644049578}
@@ -4773,6 +4406,293 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 178158e14e122db4aacaa61f767b0a07, type: 3}
+--- !u!1001 &2841092037785734028
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3451666714641850573, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+      propertyPath: pausemenu
+      value: 
+      objectReference: {fileID: 2081158452}
+    - target: {fileID: 4397502396254974356, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+      propertyPath: m_Name
+      value: PauseScreenManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 5000625235756573691, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5000625235756573691, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 996.8257
+      objectReference: {fileID: 0}
+    - target: {fileID: 5000625235756573691, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 523.57117
+      objectReference: {fileID: 0}
+    - target: {fileID: 5000625235756573691, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.3127222
+      objectReference: {fileID: 0}
+    - target: {fileID: 5000625235756573691, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5000625235756573691, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5000625235756573691, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5000625235756573691, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5000625235756573691, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5000625235756573691, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5000625235756573691, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cb0c6ac0de07d9a4e92d25bd259116ed, type: 3}
+--- !u!1001 &4064962110323734332
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1166592174}
+    m_Modifications:
+    - target: {fileID: 759216159499616267, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_Name
+      value: RocketShip
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.14400001
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.8174339
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.11400001
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.7734277
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1.4783936
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 2.4118042
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487890491209082982, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6624260759837310365, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: balanceReadout
+      value: 
+      objectReference: {fileID: 1463780548}
+    - target: {fileID: 6624260759837310365, guid: 42275745f6474e641a982979568afcb4, type: 3}
+      propertyPath: inventoryReadout
+      value: 
+      objectReference: {fileID: 1463780549}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 42275745f6474e641a982979568afcb4, type: 3}
+--- !u!1001 &6627340858610409440
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3449974017456907810, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_Name
+      value: PlayerInventoryManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 4666296983660380992, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 1333135970}
+    - target: {fileID: 4666296983660380992, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: balanceReadout
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4666296983660380992, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: inventoryReadout
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8698865630610943041, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4b8236517f89f6c4b9fac263178ca6a1, type: 3}
 --- !u!1001 &6753900533316376848
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/space-trader/Assets/Scripts/Trade/PlayerInventory/BalanceReadout.cs
+++ b/space-trader/Assets/Scripts/Trade/PlayerInventory/BalanceReadout.cs
@@ -5,24 +5,17 @@ using UnityEngine;
 
 public class BalanceReadout : MonoBehaviour
 {
-    public static BalanceReadout Instance;
     public TextMeshProUGUI balanceReadout;
 
-    private void Awake()
-    {
-        if (Instance == null)
-        {
-            Instance = this;
-            //DontDestroyOnLoad(gameObject);
-        }
-        else Destroy(gameObject);
-    }
-
-    // Start is called before the first frame update
     void Start()
     {
-        balanceReadout = GetComponent<TextMeshProUGUI>();
+        //balanceReadout = GetComponentInChildren<TextMeshProUGUI>();
+        //UpdateBalanceReadout();
     }
 
-    //public TextMeshProUGUI GetBalanceReadout() { return balanceReadout; }
+    public void UpdateBalanceReadout()
+    {
+        Debug.Log(PlayerInventoryManager.Instance.player.playerMoney + "");
+        balanceReadout.text = "Balance: " + PlayerInventoryManager.Instance.player.playerMoney + "";
+    }
 }

--- a/space-trader/Assets/Scripts/Trade/PlayerInventory/InventoryReadout.cs
+++ b/space-trader/Assets/Scripts/Trade/PlayerInventory/InventoryReadout.cs
@@ -5,24 +5,30 @@ using UnityEngine;
 
 public class InventoryReadout : MonoBehaviour
 {
-    public static InventoryReadout Instance;
     public TextMeshProUGUI inventoryReadout;
 
-    private void Awake()
+    private void Start()
     {
-        if (Instance == null)
+        //inventoryReadout = GetComponentInChildren<TextMeshProUGUI>();
+        //UpdateInventoryReadout();
+    }
+
+    public void UpdateInventoryReadout()
+    {
+        inventoryReadout.text = "";
+
+        foreach (TradeItem item in PlayerInventoryManager.Instance.allTradeItems)
         {
-            Instance = this;
-            //DontDestroyOnLoad(gameObject);
+            Debug.Log("Adding " + item.itemName + " to Readout");
+            /*if (inventoryReadout.text == null || inventoryReadout == null)
+            {
+                Debug.Log("frick me dude");
+            }*/
+            if (PlayerInventoryManager.Instance.player == null)
+            {
+                Debug.Log("frick me dude");
+            }
+            inventoryReadout.text += item.itemName + ": " + PlayerInventoryManager.Instance.player.cargoHold[item] + "\n";
         }
-        else Destroy(gameObject);
     }
-
-    // Start is called before the first frame update
-    void Start()
-    {
-        inventoryReadout = GetComponent<TextMeshProUGUI>();
-    }
-
-    //public static TextMeshProUGUI GetInventoryReadout() { return inventoryReadout; }
 }

--- a/space-trader/Assets/Scripts/Trade/PlayerInventory/PlayerInventoryManager.cs
+++ b/space-trader/Assets/Scripts/Trade/PlayerInventory/PlayerInventoryManager.cs
@@ -22,8 +22,8 @@ public class PlayerInventoryManager : MonoBehaviour
     public TradeItem[] allTradeItems;
 
     //Text fields to display inventory and balance
-    public TextMeshProUGUI inventoryReadout;
-    public TextMeshProUGUI balanceReadout;
+    //public InventoryReadout inventoryReadout;
+    //public BalanceReadout balanceReadout;
 
     //List of Agents the player has at their disposal goes here
 
@@ -37,24 +37,9 @@ public class PlayerInventoryManager : MonoBehaviour
         else Destroy(gameObject);
     }
 
-    private void Start()
+    /*public void ReloadInventoryReadout()
     {
-
-    }
-
-    public void ReloadInventoryReadout()
-    {
-        inventoryReadout = InventoryReadout.Instance.inventoryReadout;
-        balanceReadout = BalanceReadout.Instance.balanceReadout;
-
-        inventoryReadout.text = "";
-        balanceReadout.text = "";
-
-        foreach (TradeItem item in allTradeItems)
-        {
-            Debug.Log("Adding " + item.itemName + " to Readout");
-            inventoryReadout.text += item.itemName + ": " + player.cargoHold[item] + "\n";
-        }
-        balanceReadout.text = "Balance: " + player.playerMoney + "";
-    }
+        inventoryReadout.UpdateInventoryReadout();
+        balanceReadout.UpdateBalanceReadout();
+    }*/
 }

--- a/space-trader/Assets/Scripts/Trade/PlayerInventory/PlayerShipAndInventory.cs
+++ b/space-trader/Assets/Scripts/Trade/PlayerInventory/PlayerShipAndInventory.cs
@@ -48,6 +48,9 @@ public class PlayerShipAndInventory : MonoBehaviour
         {
             cargoHold[item] = 0;
         }
+
+        PlayerInventoryManager.Instance.player = this;
+
         inventoryReadout.UpdateInventoryReadout();
         balanceReadout.UpdateBalanceReadout();
     }

--- a/space-trader/Assets/Scripts/Trade/PlayerInventory/PlayerShipAndInventory.cs
+++ b/space-trader/Assets/Scripts/Trade/PlayerInventory/PlayerShipAndInventory.cs
@@ -30,6 +30,10 @@ public class PlayerShipAndInventory : MonoBehaviour
     /// </summary>
     private Image playerSprite;
 
+    //readouts for inventory and balance
+    [SerializeField] InventoryReadout inventoryReadout;
+    [SerializeField] BalanceReadout balanceReadout;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -44,7 +48,8 @@ public class PlayerShipAndInventory : MonoBehaviour
         {
             cargoHold[item] = 0;
         }
-        PlayerInventoryManager.Instance.ReloadInventoryReadout();
+        inventoryReadout.UpdateInventoryReadout();
+        balanceReadout.UpdateBalanceReadout();
     }
 
     /// <summary>

--- a/space-trader/Assets/Scripts/Trade/TradeManager.cs
+++ b/space-trader/Assets/Scripts/Trade/TradeManager.cs
@@ -9,6 +9,9 @@ public class TradeManager: MonoBehaviour
 
     public TravelManager travelManager;
     public ConfirmationWindow confirmationWindow;
+
+    [SerializeField] InventoryReadout inventoryReadout;
+    [SerializeField] BalanceReadout balanceReadout;
     //[SerializeField] TradeUI tradeWindow;
 
     private void Awake()
@@ -63,7 +66,9 @@ public class TradeManager: MonoBehaviour
                     Debug.Log("Remaining currency: " + PlayerInventoryManager.Instance.player.playerMoney);
 
                     panel.ResetUI();
-                    PlayerInventoryManager.Instance.ReloadInventoryReadout();
+                    inventoryReadout.UpdateInventoryReadout();
+                    balanceReadout.UpdateBalanceReadout();
+                    //PlayerInventoryManager.Instance.ReloadInventoryReadout();
                     return true;
                 }
                 else //The player doesn't have space for the new items
@@ -96,7 +101,9 @@ public class TradeManager: MonoBehaviour
                 Debug.Log("Current currency total: " + PlayerInventoryManager.Instance.player.playerMoney);
 
                 panel.ResetUI();
-                PlayerInventoryManager.Instance.ReloadInventoryReadout();
+                inventoryReadout.UpdateInventoryReadout();
+                balanceReadout.UpdateBalanceReadout();
+                //PlayerInventoryManager.Instance.ReloadInventoryReadout();
                 return true;
             }
             else //the player doesn't have what they want to sell

--- a/space-trader/Assets/Scripts/Travel/GalaxyMap.cs
+++ b/space-trader/Assets/Scripts/Travel/GalaxyMap.cs
@@ -7,6 +7,8 @@ public class TravelManager : MonoBehaviour
     public GameObject rocketShip;
     private Vector3 targetPosition;
 
+    [SerializeField] BalanceReadout balanceReadout;
+
     public void MoveToPlanet(Planet targetPlanet)
     {
         int totalCost = CalculateTravelCost(currentPlanet, targetPlanet);
@@ -15,7 +17,8 @@ public class TravelManager : MonoBehaviour
         {
             // Deduct the currency here
             PlayerInventoryManager.Instance.player.playerMoney -= totalCost;
-            PlayerInventoryManager.Instance.ReloadInventoryReadout();
+            balanceReadout.UpdateBalanceReadout();
+            //PlayerInventoryManager.Instance.ReloadInventoryReadout();
             //Debug.Log("Remaining currency: " + PlayerInventoryManager.Instance.player.playerMoney);
 
             // Update the rocket's target position and start coroutine to move it

--- a/space-trader/Assets/Scripts/UI/PauseMenu.cs
+++ b/space-trader/Assets/Scripts/UI/PauseMenu.cs
@@ -5,8 +5,15 @@ using UnityEngine.SceneManagement;
 
 public class PauseMenu : MonoBehaviour
 {
-    public static bool GameIsPaused = false;
+    public static bool GameIsPaused;
     [SerializeField] GameObject pausemenu;
+
+    private void Start()
+    {
+        GameIsPaused = false;
+        pausemenu.SetActive(false);
+    }
+
     void Update() 
     {
         if (Input.GetKeyDown(KeyCode.Escape))
@@ -34,6 +41,8 @@ public class PauseMenu : MonoBehaviour
     }
     public void BacktoMain() 
     {
+        GameIsPaused = false;
+        pausemenu.SetActive(false);
         SceneManager.LoadScene("MainMenu");
     }
     public void QuitGame() 


### PR DESCRIPTION
<!---
Pull Request template inspired by the one made by Rob R. for both 601's Bat Bots and 603's game 3 group 2 submission.
Link to the file in Getting Into The Industry Simulator repo: https://github.com/amonjerro/applyToTheIndustrySim/tree/main/.github
Remove these comments as you see fit when filling in the PR info.
--->
## What did you add in this branch?
<!---Can be brief, but please go into some detail as to what was added/changed/removed/etc.--->
Fixed issue where Inventory and Balance readouts would break on reloading Game scene from MainMenu.

_**Discovered new issue where TradeUI buttons break on reloading Game scene from MainMenu.**_
Need to refactor Singleton implementations to have more robust object reference declaration on scene load.
## How can we test these changes?
<!---Give instructions on how to test this branch's changes--->
Go into MainMenu and play
Enter Game scene
Exit back to MainMenu via the Pause screen
Re-enter Game Scene
Do the text boxes break? Are any NullObjectReferenceExceptions thrown?
## Relevant screenshots (if applicable):
<!---If changes are purely visual, please post screenshots here to streamline the review process--->

## What week is this due by?
<!---This can be with respect to playtests, alpha/beta/final submissions, weekends, etc.--->
Playtest 1